### PR TITLE
Use query name as span name

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
   def project do
     [
       app: :opentelemetry_absinthe,
-      version: "1.1.0",
+      version: "1.1.1",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
With this PR we attempt to make the absinthe spans slightly more useful by assigning span_names based on the query document provided by the client.

Instead of `absinthe graphql resolution`,  whenever possible spans will be named something like `mutation uploadCardThumbnail(input: $input)` or `query listCards(input: $input)`

<img width="1759" alt="image" src="https://user-images.githubusercontent.com/923630/207237745-487a8ae1-d03a-48d1-b7c5-75af199d1b17.png">
